### PR TITLE
updated deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+- Updated dependencies.
+
 ## 1.1.1
 
 - Altered `configFinder.js` to look for both `.multi-db-config.json` and `.multi-db-driver-config.json` when searching for user defined config file.

--- a/multi-db-driver.js
+++ b/multi-db-driver.js
@@ -22,7 +22,7 @@ async function multiDb (params) {
     try {
       if (multiDb.drivers[key] === '@electric-sql/pglite') {
         multiDb.drivers[key] = await import(multiDb.drivers[key])
-      } else if (Object.prototype.hasOwnProperty.call(multiDb.drivers[key], 'PGlite')) {
+      } else if (Object.getPrototypeOf(multiDb.drivers[key]) === null) {
         // do  nothing
       } else {
         multiDb.drivers[key] = require(multiDb.drivers[key])

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
         "@electric-sql/pglite": "0.3.15",
         "better-sqlite3": "12.6.2",
         "c8": "10.1.3",
-        "mariadb": "3.4.5",
+        "mariadb": "3.5.1",
         "mocha": "11.7.5",
-        "mysql2": "3.16.3",
+        "mysql2": "3.17.3",
         "pg": "8.18.0",
         "standard": "17.1.2"
       },
@@ -346,7 +346,9 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -368,6 +370,8 @@
       "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -397,7 +401,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1588,7 +1591,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1796,7 +1798,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -1888,7 +1889,6 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -1939,7 +1939,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -1956,7 +1955,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -2745,9 +2743,9 @@
       "license": "MIT"
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2755,6 +2753,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -3623,9 +3625,9 @@
       "license": "ISC"
     },
     "node_modules/lru.min": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
-      "integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+      "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3655,20 +3657,30 @@
       }
     },
     "node_modules/mariadb": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-3.4.5.tgz",
-      "integrity": "sha512-gThTYkhIS5rRqkVr+Y0cIdzr+GRqJ9sA2Q34e0yzmyhMCwyApf3OKAC1jnF23aSlIOqJuyaUFUcj7O1qZslmmQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/mariadb/-/mariadb-3.5.1.tgz",
+      "integrity": "sha512-ObKf/e7jU8pmwa5wTs1UwhLMrQYRBDwXPndej2Dv/rvbqsokJYlymubsNtpakVfjI+hd0bG3U6tiuVunDYoLtA==",
       "dev": true,
       "license": "LGPL-2.1-or-later",
       "dependencies": {
-        "@types/geojson": "^7946.0.16",
-        "@types/node": "^24.0.13",
         "denque": "^2.1.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.2",
         "lru-cache": "^10.4.3"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@types/geojson": ">=7946.0.0",
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/geojson": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/math-intrinsics": {
@@ -3797,9 +3809,9 @@
       "license": "MIT"
     },
     "node_modules/mysql2": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.16.3.tgz",
-      "integrity": "sha512-+3XhQEt4FEFuvGV0JjIDj4eP2OT/oIj/54dYvqhblnSzlfcxVOuj+cd15Xz6hsG4HU1a+A5+BA9gm0618C4z7A==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.17.3.tgz",
+      "integrity": "sha512-uCLmQMe1l96Sb6J3Ii8YJTOWJkhRmxlLJFdOfhD68jPpGTzK2fxEkFMpf5gewyHgUB0FJKzuAuPhYS+oPB0/vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3808,30 +3820,12 @@
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.7.2",
         "long": "^5.3.2",
-        "lru.min": "^1.1.3",
+        "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "seq-queue": "^0.0.5",
-        "sqlstring": "^2.3.3"
+        "sql-escaper": "^1.3.3"
       },
       "engines": {
         "node": ">= 8.0"
-      }
-    },
-    "node_modules/mysql2/node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/named-placeholders": {
@@ -4216,7 +4210,6 @@
       "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -4937,12 +4930,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/seq-queue": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "dev": true
-    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -5198,14 +5185,20 @@
         "node": ">= 10.x"
       }
     },
-    "node_modules/sqlstring": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+    "node_modules/sql-escaper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "bun": ">=1.0.0",
+        "deno": ">=2.0.0",
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
       }
     },
     "node_modules/stack-trace": {
@@ -5780,7 +5773,9 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "@electric-sql/pglite": "0.3.15",
     "better-sqlite3": "12.6.2",
     "c8": "10.1.3",
-    "mariadb": "3.4.5",
+    "mariadb": "3.5.1",
     "mocha": "11.7.5",
-    "mysql2": "3.16.3",
+    "mysql2": "3.17.3",
     "pg": "8.18.0",
     "standard": "17.1.2"
   },


### PR DESCRIPTION
code change in multi-db-driver.js handles the mariadb package now exporting a null‑prototype module object ([Module: null prototype] {}) in v3.5.1