### PR TITLE
Return query errors on db.query

### DIFF
--- a/multi-db-driver.js
+++ b/multi-db-driver.js
@@ -105,6 +105,7 @@ async function multiDb (params) {
       logger.error('Query attempted: ', query)
       logger.error('Params supplied: ', params)
       logger.error(e)
+      return { error: e }
     }
   }
 
@@ -168,6 +169,7 @@ async function multiDb (params) {
       logger.error('Query attempted: ', query)
       logger.error('Params supplied: ', params)
       logger.error(e)
+      return { error: e }
     }
   }
 
@@ -227,6 +229,7 @@ async function multiDb (params) {
       logger.error('Query attempted: ', query)
       logger.error('Params supplied: ', params)
       logger.error(e)
+      return { error: e }
     }
   }
 
@@ -305,6 +308,7 @@ async function multiDb (params) {
       logger.error('Query attempted: ', query)
       logger.error('Params supplied: ', params)
       logger.error(e)
+      return { error: e }
     }
   }
 
@@ -358,6 +362,7 @@ async function multiDb (params) {
       logger.error('Query attempted: ', query)
       logger.error('Params supplied: ', params)
       logger.error(e)
+      return { error: e }
     }
   }
 


### PR DESCRIPTION
Because of how each query method is wrapped in its own try/catch, it's currently not possible for an app using this module to get access to the actual query errors that might happen when trying to fire one off outside of seeing them get logged into the console.

This minor change to each query method makes them return the error, this gives apps the ability to check the result for errors if they so choose.